### PR TITLE
PSDK-624 Use the pointer-events: all CSS rule on the ad player div as…

### DIFF
--- a/src/jw7-pulse.js
+++ b/src/jw7-pulse.js
@@ -414,6 +414,7 @@
             var overlays = playerContainer.getElementsByClassName("jw-overlays")[0];
             var container = document.createElement("div");
             container.id = "pulse_" + Math.random();
+            container.style.pointerEvents = "all";
             overlays.appendChild(container);
             return container;
         }


### PR DESCRIPTION
… version 7.7.0 of JW removed this. This is needed for clickhrough